### PR TITLE
Coerce integer type for yview_scroll

### DIFF
--- a/Code/Chapter2-2.py
+++ b/Code/Chapter2-2.py
@@ -93,7 +93,7 @@ class Todo(tk.Tk):
 
     def mouse_scroll(self, event):
         if event.delta:
-            self.tasks_canvas.yview_scroll(-1*(event.delta/120), "units")
+            self.tasks_canvas.yview_scroll(int(-1*(event.delta/120)), "units")
         else:
             if event.num == 5:
                 move = 1


### PR DESCRIPTION
**Issue**: Bug - exception raised for yview_scroll without integer conversion.

> Exception in Tkinter callback
> Traceback (most recent call last):
>   File "C:\Python35-32\lib\tkinter\__init__.py", line 1550, in __call__
>    return self.func(*args)
>  File "test_tk.py", line 93, in mouse_scroll
>    self.tasks_canvas.yview_scroll(-1*(event.delta/120), "units")
>  File "C:\Python35-32\lib\tkinter\__init__.py", line 1596, in yview_scroll
>     self.tk.call(self._w, 'yview', 'scroll', number, what)
> _tkinter.TclError: expected integer but got "-1.0"

**Proposed solution**: Coercion to integer type.

**Notes**: 

1. After coercion, the exception is no longer raised. Scrolling works fine.
2. The change is consistent with the 'move' variable's type.